### PR TITLE
Add support for MFA

### DIFF
--- a/O365DataRetriever.ps1
+++ b/O365DataRetriever.ps1
@@ -6,7 +6,8 @@ O365 Data Retriever - Release 0.1.0 (Aug 22nd, 2018)
 Add-Type -AssemblyName PresentationFramework, PresentationCore, WindowsBase, system.windows.forms
 
 #Refer to the XAML file
-[xml]$xml = Get-Content "C:\O365DataRetriever\MainWindow.xaml"
+[string]$xamlContent = Get-Content $(Join-Path -Path $PSScriptRoot -ChildPath 'MainWindow.xaml' )
+[xml]$xml = $xamlContent.Replace('{0}',$PSScriptRoot) 
 $xamlFile = $xml
 
 #Read & Load the xaml file
@@ -585,7 +586,7 @@ $ExportSkypeUsersButton = $Window.findname('ExportSkypeUsersButton')
 
 
 #Focus on AdminTextBox when Window loads
-$AdminTextBox.Focus()
+$AdminTextBox.Focus() | Out-Null
 
 
 #Enable the "Connect" button if text is entered in the $AdminTextBox
@@ -2005,6 +2006,6 @@ $DisconnectButton.Add_Click( {
 #endregion
 
 #Show the GUI
-$Window.ShowDialog()
+$Window.ShowDialog() | Out-Null
 
 


### PR DESCRIPTION
This provides initial support for MFA.

It appears that EXO, SPO, and SFB all implement MFA slightly differently (the compliance center follows the EXO model), so we can consider this a v0.1 MFA support, as it requires 4 separate logins (one to the O365-Data-Retriever App, and then one to each of EXO, SPO, SFB). However, it works.

This also adds a timer to the data-retrieval section of the script.

Two of chwilfing's changes to Get-SPOSite are backed out. They are handled (more efficiently IMO) in my second patch, coming shortly.